### PR TITLE
Bump to 0.1.5; Python 3.13 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "proxyspy" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.5" %}
+{% set sha256 = "c130cc14b854d72930698558caa0affe6fa76840d3cd6a75b0ffc269939329e3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 288f688dcb72e05299c4765a4c77764a87ce30f780e0a2abcce9ab8252b55f86
+  sha256: {{ sha256 }}
 
 build:
   number: 0


### PR DESCRIPTION
proxyspy 0.1.5

**Destination channel:** defaults

### Links

- [PKG-9730](https://anaconda.atlassian.net/browse/PKG-9730) 
- [Upstream repository](https://github.com/anaconda/proxyspy)
- [Upstream changelog/diff](https://github.com/anaconda/proxyspy/compare/v0.1.4...v0.1.5)

### Explanation of changes:

- Proper Python 3.13 support


[PKG-9730]: https://anaconda.atlassian.net/browse/PKG-9730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ